### PR TITLE
Proposed fix for Issue # 16

### DIFF
--- a/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/NativeBuffer.java
+++ b/leveldbjni/src/main/java/org/fusesource/leveldbjni/internal/NativeBuffer.java
@@ -112,8 +112,8 @@ public class NativeBuffer extends NativeObject {
                 throw new Error("The object has already been deleted.");
             } else if( r==0 ) {
                 NativeBufferJNI.free(self);
+                self = 0;
             }
-            self = 0;
         }
     }
 


### PR DESCRIPTION
...eBuffer.java

 `self` is only cleared when it is free'd. 
