### PR TITLE
Add support for solaris native libraries

### DIFF
--- a/leveldbjni-all/pom.xml
+++ b/leveldbjni-all/pom.xml
@@ -84,7 +84,25 @@
       <version>1.8</version>
       <scope>provided</scope>
     </dependency>
-    
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni-sunos32-x86</artifactId>
+      <version>99-master-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni-sunos64-amd64</artifactId>
+      <version>99-master-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni-sunos64-sparcv9</artifactId>
+      <version>99-master-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -119,7 +137,10 @@
               META-INF/native/osx/libleveldbjni.jnilib;osname=macosx;processor=x86,
               META-INF/native/osx/libleveldbjni.jnilib;osname=macosx;processor=x86-64,
               META-INF/native/linux32/libleveldbjni.so;osname=Linux;processor=x86,
-              META-INF/native/linux64/libleveldbjni.so;osname=Linux;processor=x86-64
+              META-INF/native/linux64/libleveldbjni.so;osname=Linux;processor=x86-64,
+	      META-INF/native/sunos32/x86/libleveldbjni.so;osname=SunOS;processor=x86,
+	      META-INF/native/sunos64/amd64/libleveldbjni.so;osname=SunOS;processor=x86-64,
+	      META-INF/native/sunos64/sparcv9/libleveldbjni.so;osname=SunOS;processor=sparcv9
             </Bundle-NativeCode>
          </instructions>
         </configuration>

--- a/leveldbjni-sunos32-x86/pom.xml
+++ b/leveldbjni-sunos32-x86/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2011, FuseSource Corp.  All rights reserved.
+
+      http://fusesource.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of FuseSource Corp. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fusesource.leveldbjni</groupId>
+    <artifactId>leveldbjni-project</artifactId>
+    <version>99-master-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.fusesource.leveldbjni</groupId>
+  <artifactId>leveldbjni-sunos32-x86</artifactId>
+  <version>99-master-SNAPSHOT</version>
+  
+  <name>${project.artifactId}</name>
+  <description>The leveldbjni solaris 32 native libraries on x86 machines</description>
+      
+  <dependencies>
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni</artifactId>
+      <version>99-master-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>${basedir}/../leveldbjni/src/test/java</testSourceDirectory>
+     
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <classesDirectory>${basedir}/target/generated-sources/hawtjni/lib</classesDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.fusesource.hawtjni</groupId>
+        <artifactId>maven-hawtjni-plugin</artifactId>
+        <version>${hawtjni-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+	  <platform>sunos32/x86</platform>
+          <name>leveldbjni</name>
+          <classified>false</classified>
+          <nativeSrcDependency>
+            <groupId>org.fusesource.leveldbjni</groupId>
+            <artifactId>leveldbjni</artifactId>
+            <version>${project.version}</version>
+            <classifier>native-src</classifier>
+            <type>zip</type>
+          </nativeSrcDependency>
+          <configureArgs>
+            <arg>--with-leveldb=${env.LEVELDB_HOME}</arg>
+            <arg>--with-snappy=${env.SNAPPY_HOME}</arg>
+          </configureArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/leveldbjni-sunos64-amd64/pom.xml
+++ b/leveldbjni-sunos64-amd64/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2011, FuseSource Corp.  All rights reserved.
+
+      http://fusesource.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of FuseSource Corp. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fusesource.leveldbjni</groupId>
+    <artifactId>leveldbjni-project</artifactId>
+    <version>99-master-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.fusesource.leveldbjni</groupId>
+  <artifactId>leveldbjni-sunos64-amd64</artifactId>
+  <version>99-master-SNAPSHOT</version>
+  
+  <name>${project.artifactId}</name>
+  <description>The leveldbjni solaris 64 native libraries on amd64 machines</description>
+      
+  <dependencies>
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni</artifactId>
+      <version>99-master-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>${basedir}/../leveldbjni/src/test/java</testSourceDirectory>
+     
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <classesDirectory>${basedir}/target/generated-sources/hawtjni/lib</classesDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.fusesource.hawtjni</groupId>
+        <artifactId>maven-hawtjni-plugin</artifactId>
+        <version>${hawtjni-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+	  <platform>sunos64/amd64</platform>
+          <name>leveldbjni</name>
+          <classified>false</classified>
+          <nativeSrcDependency>
+            <groupId>org.fusesource.leveldbjni</groupId>
+            <artifactId>leveldbjni</artifactId>
+            <version>${project.version}</version>
+            <classifier>native-src</classifier>
+            <type>zip</type>
+          </nativeSrcDependency>
+          <configureArgs>
+            <arg>--with-leveldb=${env.LEVELDB_HOME}</arg>
+            <arg>--with-snappy=${env.SNAPPY_HOME}</arg>
+	    <arg>CFLAGS=-m64</arg>
+	    <arg>CXXFLAGS=-m64</arg>
+          </configureArgs>
+        </configuration>
+      </plugin>
+      <plugin>                                                                                                                                                            
+        <groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-surefire-plugin</artifactId>
+	<version>2.4.3</version>
+	<configuration>
+	  <redirectTestOutputToFile>true</redirectTestOutputToFile>
+	  <forkMode>once</forkMode>
+	  <argLine>-d64 -ea</argLine>
+	  <failIfNoTests>false</failIfNoTests>
+	  <workingDirectory>${project.build.directory}</workingDirectory>
+	  <includes>
+	    <include>**/*Test.java</include>
+	  </includes>
+	</configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/leveldbjni-sunos64-sparcv9/pom.xml
+++ b/leveldbjni-sunos64-sparcv9/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (C) 2011, FuseSource Corp.  All rights reserved.
+
+      http://fusesource.com
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of FuseSource Corp. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fusesource.leveldbjni</groupId>
+    <artifactId>leveldbjni-project</artifactId>
+    <version>99-master-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.fusesource.leveldbjni</groupId>
+  <artifactId>leveldbjni-sunos64-sparcv9</artifactId>
+  <version>99-master-SNAPSHOT</version>
+  
+  <name>${project.artifactId}</name>
+  <description>The leveldbjni solaris 64 native libraries on sparcv9 machines</description>
+      
+  <dependencies>
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni</artifactId>
+      <version>99-master-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>${basedir}/../leveldbjni/src/test/java</testSourceDirectory>
+     
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <classesDirectory>${basedir}/target/generated-sources/hawtjni/lib</classesDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.fusesource.hawtjni</groupId>
+        <artifactId>maven-hawtjni-plugin</artifactId>
+        <version>${hawtjni-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+	  <platform>sunos64/sparcv9</platform>
+          <name>leveldbjni</name>
+          <classified>false</classified>
+          <nativeSrcDependency>
+            <groupId>org.fusesource.leveldbjni</groupId>
+            <artifactId>leveldbjni</artifactId>
+            <version>${project.version}</version>
+            <classifier>native-src</classifier>
+            <type>zip</type>
+          </nativeSrcDependency>
+          <configureArgs>
+            <arg>--with-leveldb=${env.LEVELDB_HOME}</arg>
+            <arg>--with-snappy=${env.SNAPPY_HOME}</arg>
+	    <arg>CFLAGS=-m64</arg>
+	    <arg>CXXFLAGS=-m64</arg>
+          </configureArgs>
+        </configuration>
+      </plugin>
+      <plugin>                                                                                                                                                            
+        <groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-surefire-plugin</artifactId>
+	<version>2.4.3</version>
+	<configuration>
+	  <redirectTestOutputToFile>true</redirectTestOutputToFile>
+	  <forkMode>once</forkMode>
+	  <argLine>-d64 -ea</argLine>
+	  <failIfNoTests>false</failIfNoTests>
+	  <workingDirectory>${project.build.directory}</workingDirectory>
+	  <includes>
+	    <include>**/*Test.java</include>
+	  </includes>
+	</configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/leveldbjni/src/main/native-package/src/leveldbjni.h
+++ b/leveldbjni/src/main/native-package/src/leveldbjni.h
@@ -58,7 +58,9 @@
   #include <string.h>
 #endif
 
-#ifdef HAVE_SYS_ERRNO_H
+#if defined(__sun)
+  #include <errno.h>
+#elif defined(HAVE_SYS_ERRNO_H)
   #include <sys/errno.h>
 #endif
 

--- a/pom.xml
+++ b/pom.xml
@@ -299,5 +299,26 @@
       </modules>
     </profile>
 
+    <profile>
+      <id>sunos32-x86</id>
+      <modules>
+        <module>leveldbjni-sunos32-x86</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>sunos64-amd64</id>
+      <modules>
+        <module>leveldbjni-sunos64-amd64</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>sunos64-sparcv9</id>
+      <modules>
+        <module>leveldbjni-sunos64-sparcv9</module>
+      </modules>
+    </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
I am adding support for native library build on solaris:
  -- sunos32 on x86
  -- sunos64 on amd64
  -- sunos64 on sparcv9
I am not adding sparc32 lib, since 32-bit Solaris JNI is actually EOL, plus there is a bug for JNI code on sparc32.

Some questions to discuss:
1. I have my changes tested on leveldbjni release 1.8 and it works well.
    I am not able to test it on the current SNAPSHOT version due to this issue I posted:
    https://github.com/fusesource/leveldbjni/issues/57
    Could you help with this issue?

2. Since solaris runs on different processors, I have a new loading path for hawtjni-runtime updated.
    Please see:
    https://github.com/fusesource/hawtjni/pull/19
    With dependency version for hawtjni updated in the next release, the test cases should pass and
    build should  succeed.
    How does this look?

3. I updated the osgi bundle for leveldbjni-all. I am assuming the next release will show up in
    maven's central repository also. 
    If you don't have solaris or sparc machines available, we can offer the built leveldb and jni native
    libraries binaries.
    But I am not clear how the releases work?

Thanks for help. 
Please let me know any comments for this pull request.