### PR TITLE
Fix a Typo in Readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ You just need to add the following dependency to your Maven pom.
       </dependency>
     </dependencies>
 
-By using the `leveldbjni-all` then the Java driver of leveldb is being used. If you want to use the navitive drivers, then use the os specific dependency instead of `leveldbjni-all`. For example to use linux 64 bit, then use this dependency:
+By using the `leveldbjni-all` then the Java driver of leveldb is being used. If you want to use the native drivers, then use the os specific dependency instead of `leveldbjni-all`. For example to use linux 64 bit, then use this dependency:
 
     <dependencies>
       <dependency>


### PR DESCRIPTION
Fixed a mistyped word "navitive" and changed it to "native".