### PR TITLE
Make patch of leveldb to support aarch64

### DIFF
--- a/leveldb_aarch64.patch
+++ b/leveldb_aarch64.patch
@@ -1,0 +1,64 @@
+diff --git a/build_detect_platform b/build_detect_platform
+index d50869d..4c9b0b6 100755
+--- a/build_detect_platform
++++ b/build_detect_platform
+@@ -203,9 +203,9 @@ echo "CXX=$CXX" >> $OUTPUT
+ echo "PLATFORM=$PLATFORM" >> $OUTPUT
+ echo "PLATFORM_LDFLAGS=$PLATFORM_LDFLAGS" >> $OUTPUT
+ echo "PLATFORM_LIBS=$PLATFORM_LIBS" >> $OUTPUT
+-echo "PLATFORM_CCFLAGS=$PLATFORM_CCFLAGS" >> $OUTPUT
+-echo "PLATFORM_CXXFLAGS=$PLATFORM_CXXFLAGS" >> $OUTPUT
+-echo "PLATFORM_SHARED_CFLAGS=$PLATFORM_SHARED_CFLAGS" >> $OUTPUT
++echo "PLATFORM_CCFLAGS=$PLATFORM_CCFLAGS $PLATFORM_SHARED_CFLAGS" >> $OUTPUT
++echo "PLATFORM_CXXFLAGS=$PLATFORM_CXXFLAGS $PLATFORM_SHARED_CFLAGS" >> $OUTPUT
++echo "PLATFORM_SHARED_CFLAGS=" >> $OUTPUT
+ echo "PLATFORM_SHARED_EXT=$PLATFORM_SHARED_EXT" >> $OUTPUT
+ echo "PLATFORM_SHARED_LDFLAGS=$PLATFORM_SHARED_LDFLAGS" >> $OUTPUT
+ echo "PLATFORM_SHARED_VERSIONED=$PLATFORM_SHARED_VERSIONED" >> $OUTPUT
+diff --git a/include/leveldb/slice.h b/include/leveldb/slice.h
+index 74ea8fa..135bbd7 100644
+--- a/include/leveldb/slice.h
++++ b/include/leveldb/slice.h
+@@ -77,7 +77,6 @@ class Slice {
+             (memcmp(data_, x.data_, x.size_) == 0));
+   }
+ 
+- private:
+   const char* data_;
+   size_t size_;
+ 
+diff --git a/port/atomic_pointer.h b/port/atomic_pointer.h
+index e17bf43..94d4ecb 100644
+--- a/port/atomic_pointer.h
++++ b/port/atomic_pointer.h
+@@ -36,6 +36,8 @@
+ #define ARCH_CPU_X86_FAMILY 1
+ #elif defined(__ARMEL__)
+ #define ARCH_CPU_ARM_FAMILY 1
++#elif defined(__aarch64__)
++#define ARCH_CPU_ARM64_FAMILY 1
+ #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
+ #define ARCH_CPU_PPC_FAMILY 1
+ #endif
+@@ -93,6 +95,13 @@ inline void MemoryBarrier() {
+ }
+ #define LEVELDB_HAVE_MEMORY_BARRIER
+ 
++// ARM64
++#elif defined(ARCH_CPU_ARM64_FAMILY)
++inline void MemoryBarrier() {
++  asm volatile("dmb sy" : : : "memory");
++}
++#define LEVELDB_HAVE_MEMORY_BARRIER
++
+ // PPC
+ #elif defined(ARCH_CPU_PPC_FAMILY) && defined(__GNUC__)
+ inline void MemoryBarrier() {
+@@ -216,6 +225,7 @@ class AtomicPointer {
+ #undef LEVELDB_HAVE_MEMORY_BARRIER
+ #undef ARCH_CPU_X86_FAMILY
+ #undef ARCH_CPU_ARM_FAMILY
++#undef ARCH_CPU_ARM64_FAMILY
+ #undef ARCH_CPU_PPC_FAMILY
+ 
+ }  // namespace port

--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,8 @@ Patch and Compile the leveldb project.  This produces a static library.
     git apply ../leveldbjni/leveldb.patch
     make libleveldb.a
 
+Notes: Apply ../leveldbjni/leveldb_aarch64.patch instead on linux64-aarch64 platform.
+
 Now use maven to build the leveldbjni project. 
     
     cd ${LEVELDBJNI_HOME}
@@ -254,6 +256,7 @@ Replace ${platform} with one of the following platform identifiers (depending on
 * win32
 * win64
 * freebsd64
+* linux64-aarch64
 
 If your platform does not have the right auto-tools levels available
 just copy the `leveldbjni-${version}-SNAPSHOT-native-src.zip` artifact


### PR DESCRIPTION
This makes a patch of leveldb to support aarch64,
before using maven to build leveldbjni for
linux64-aarch64 platform, please apply
leveldb_aarch64.patch instead leveldb.patch.