### PR TITLE
Deploy leveldbjni-all-1.8 to org.openlabtesting.leveldbjni:

### DIFF
--- a/leveldb.patch
+++ b/leveldb.patch
@@ -1,8 +1,8 @@
 diff --git a/build_detect_platform b/build_detect_platform
-index 5801d20..517db04 100755
+index d50869d..4c9b0b6 100755
 --- a/build_detect_platform
 +++ b/build_detect_platform
-@@ -195,9 +195,9 @@ echo "CXX=$CXX" >> $OUTPUT
+@@ -203,9 +203,9 @@ echo "CXX=$CXX" >> $OUTPUT
  echo "PLATFORM=$PLATFORM" >> $OUTPUT
  echo "PLATFORM_LDFLAGS=$PLATFORM_LDFLAGS" >> $OUTPUT
  echo "PLATFORM_LIBS=$PLATFORM_LIBS" >> $OUTPUT
@@ -27,3 +27,38 @@ index 74ea8fa..135bbd7 100644
    const char* data_;
    size_t size_;
  
+diff --git a/port/atomic_pointer.h b/port/atomic_pointer.h
+index e17bf43..94d4ecb 100644
+--- a/port/atomic_pointer.h
++++ b/port/atomic_pointer.h
+@@ -36,6 +36,8 @@
+ #define ARCH_CPU_X86_FAMILY 1
+ #elif defined(__ARMEL__)
+ #define ARCH_CPU_ARM_FAMILY 1
++#elif defined(__aarch64__)
++#define ARCH_CPU_ARM64_FAMILY 1
+ #elif defined(__ppc__) || defined(__powerpc__) || defined(__powerpc64__)
+ #define ARCH_CPU_PPC_FAMILY 1
+ #endif
+@@ -93,6 +95,13 @@ inline void MemoryBarrier() {
+ }
+ #define LEVELDB_HAVE_MEMORY_BARRIER
+ 
++// ARM64
++#elif defined(ARCH_CPU_ARM64_FAMILY)
++inline void MemoryBarrier() {
++  asm volatile("dmb sy" : : : "memory");
++}
++#define LEVELDB_HAVE_MEMORY_BARRIER
++
+ // PPC
+ #elif defined(ARCH_CPU_PPC_FAMILY) && defined(__GNUC__)
+ inline void MemoryBarrier() {
+@@ -216,6 +225,7 @@ class AtomicPointer {
+ #undef LEVELDB_HAVE_MEMORY_BARRIER
+ #undef ARCH_CPU_X86_FAMILY
+ #undef ARCH_CPU_ARM_FAMILY
++#undef ARCH_CPU_ARM64_FAMILY
+ #undef ARCH_CPU_PPC_FAMILY
+ 
+ }  // namespace port

--- a/leveldbjni-all/pom.xml
+++ b/leveldbjni-all/pom.xml
@@ -34,14 +34,14 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.fusesource.leveldbjni</groupId>
+    <groupId>org.openlabtesting.leveldbjni</groupId>
     <artifactId>leveldbjni-project</artifactId>
-    <version>99-master-SNAPSHOT</version>
+    <version>1.8</version>
   </parent>
 
-  <groupId>org.fusesource.leveldbjni</groupId>
+  <groupId>org.openlabtesting.leveldbjni</groupId>
   <artifactId>leveldbjni-all</artifactId>
-  <version>99-master-SNAPSHOT</version>
+  <version>1.8</version>
   <packaging>bundle</packaging>
   
   <name>${project.artifactId}</name>
@@ -49,9 +49,9 @@
       
   <dependencies>
     <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
+      <groupId>org.openlabtesting.leveldbjni</groupId>
       <artifactId>leveldbjni</artifactId>
-      <version>99-master-SNAPSHOT</version>
+      <version>1.8</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -74,12 +74,6 @@
     </dependency>
     <dependency>
       <groupId>org.fusesource.leveldbjni</groupId>
-      <artifactId>leveldbjni-freebsd64</artifactId>
-      <version>99-master-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-win32</artifactId>
       <version>1.8</version>
       <scope>provided</scope>
@@ -91,27 +85,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
-      <artifactId>leveldbjni-sunos64-amd64</artifactId>
-      <version>99-master-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
-      <artifactId>leveldbjni-sunos64-sparcv9</artifactId>
-      <version>99-master-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
-      <artifactId>leveldbjni-linux64-ppc64le</artifactId>
-      <version>99-master-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
+      <groupId>org.openlabtesting.leveldbjni</groupId>
       <artifactId>leveldbjni-linux64-aarch64</artifactId>
-      <version>99-master-SNAPSHOT</version>
+      <version>1.8</version>
       <scope>provided</scope>
     </dependency>
 
@@ -141,7 +117,7 @@
             <Implementation-Title>LevelDB JNI</Implementation-Title>
             <Implementation-Version>${project.version}</Implementation-Version>
             <Embed-Dependency>
-              *;groupId=org.fusesource.leveldbjni;inline=META-INF/native/*,
+              *;inline=META-INF/native/*,
             </Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Bundle-NativeCode>
@@ -151,10 +127,6 @@
               META-INF/native/osx/libleveldbjni.jnilib;osname=macosx;processor=x86-64,
               META-INF/native/linux32/libleveldbjni.so;osname=Linux;processor=x86,
               META-INF/native/linux64/libleveldbjni.so;osname=Linux;processor=x86-64,
-	      META-INF/native/sunos64/amd64/libleveldbjni.so;osname=SunOS;processor=x86-64,
-	      META-INF/native/sunos64/sparcv9/libleveldbjni.so;osname=SunOS;processor=sparcv9,
-              META-INF/native/freebsd64/libleveldbjni.so;osname=FreeBSD;processor=x86-64,
-              META-INF/native/linux64/ppc64le/libleveldbjni.so;osname=Linux;processor=ppc64le,
               META-INF/native/linux64/aarch64/libleveldbjni.so;osname=Linux;processor=aarch64
             </Bundle-NativeCode>
          </instructions>
@@ -166,12 +138,11 @@
   <profiles>
     <profile>
       <id>release</id>
-      
       <dependencies>
         <dependency>
-          <groupId>org.fusesource.leveldbjni</groupId>
+          <groupId>org.openlabtesting.leveldbjni</groupId>
           <artifactId>leveldbjni</artifactId>
-          <version>99-master-SNAPSHOT</version>
+          <version>1.8</version>
           <classifier>sources</classifier>
           <optional>true</optional>
         </dependency>

--- a/leveldbjni-linux64-aarch64/pom.xml
+++ b/leveldbjni-linux64-aarch64/pom.xml
@@ -30,23 +30,23 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.fusesource.leveldbjni</groupId>
+    <groupId>org.openlabtesting.leveldbjni</groupId>
     <artifactId>leveldbjni-project</artifactId>
-    <version>99-master-SNAPSHOT</version>
+    <version>1.8</version>
   </parent>
 
-  <groupId>org.fusesource.leveldbjni</groupId>
+  <groupId>org.openlabtesting.leveldbjni</groupId>
   <artifactId>leveldbjni-linux64-aarch64</artifactId>
-  <version>99-master-SNAPSHOT</version>
+  <version>1.8</version>
   
   <name>${project.artifactId}</name>
   <description>The leveldbjni linux 64 native libraries on aarch64 machines</description>
       
   <dependencies>
     <dependency>
-      <groupId>org.fusesource.leveldbjni</groupId>
+      <groupId>org.openlabtesting.leveldbjni</groupId>
       <artifactId>leveldbjni</artifactId>
-      <version>99-master-SNAPSHOT</version>
+      <version>1.8</version>
     </dependency>
   </dependencies>
 
@@ -78,7 +78,7 @@
           <name>leveldbjni</name>
           <classified>false</classified>
           <nativeSrcDependency>
-            <groupId>org.fusesource.leveldbjni</groupId>
+            <groupId>org.openlabtesting.leveldbjni</groupId>
             <artifactId>leveldbjni</artifactId>
             <version>${project.version}</version>
             <classifier>native-src</classifier>

--- a/leveldbjni/pom.xml
+++ b/leveldbjni/pom.xml
@@ -34,14 +34,14 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.fusesource.leveldbjni</groupId>
+    <groupId>org.openlabtesting.leveldbjni</groupId>
     <artifactId>leveldbjni-project</artifactId>
-    <version>99-master-SNAPSHOT</version>
+    <version>1.8</version>
   </parent>
 
-  <groupId>org.fusesource.leveldbjni</groupId>
+  <groupId>org.openlabtesting.leveldbjni</groupId>
   <artifactId>leveldbjni</artifactId>
-  <version>99-master-SNAPSHOT</version>
+  <version>1.8</version>
   <packaging>jar</packaging>
   
   <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
     <version>1.9</version>
   </parent>
 
-  <groupId>org.fusesource.leveldbjni</groupId>
+  <groupId>org.openlabtesting.leveldbjni</groupId>
   <artifactId>leveldbjni-project</artifactId>
-  <version>99-master-SNAPSHOT</version>
+  <version>1.8</version>
   <packaging>pom</packaging>
   
   <name>${project.artifactId}</name>
@@ -89,17 +89,20 @@
   </licenses>
   
   <scm>
-    <connection>scm:git:git://github.com/fusesource/leveldbjni.git</connection>
-    <developerConnection>scm:git:git@github.com:fusesource/leveldbjni.git</developerConnection>
-    <url>https://github.com/fusesource/leveldbjni</url>
+    <connection>scm:git:git://github.com/theopenlab/leveldbjni.git</connection>
+    <developerConnection>scm:git:git@github.com:theopenlab/leveldbjni.git</developerConnection>
+    <url>https://github.com/theopenlab/leveldbjni</url>
   </scm>
 
   <distributionManagement>
-    <site>
-      <id>website.fusesource.org</id>
-      <name>website</name>
-      <url>dav:http://fusesource.com/forge/dav/${forge-project-id}/maven/${project.version}</url>
-    </site>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
   </distributionManagement> 
   
   <developers>
@@ -109,6 +112,11 @@
       <email>hiram@hiramchirino.com</email>
       <url>http://hiramchirino.com</url>
       <timezone>GMT-5</timezone>
+    </developer>
+    <developer>
+      <id>huangtianhua</id>
+      <name>Tianhua Huang</name>
+      <email>huangtianhua223@gmail.com</email>
     </developer>
   </developers>
   
@@ -237,6 +245,10 @@
           <name>FuseSource Community Snapshot Repository</name>
           <url>http://repo.fusesource.com/nexus/content/groups/public-snapshots</url>
         </pluginRepository>
+        <pluginRepository>
+          <id>sonatype-nexus</id>
+          <url>https://oss.sonatype.org/content/repositories/public</url>
+        </pluginRepository>
       </pluginRepositories>
     </profile>
     
@@ -246,12 +258,12 @@
         <module>leveldbjni-osx</module>
         <module>leveldbjni-linux32</module>
         <module>leveldbjni-linux64</module>
-        <module>leveldbjni-freebsd64</module>
+        <!--module>leveldbjni-freebsd64</module-->
         <module>leveldbjni-win32</module>
         <module>leveldbjni-win64</module>
-        <module>leveldbjni-sunos64-amd64</module>
+        <!--module>leveldbjni-sunos64-amd64</module>
         <module>leveldbjni-sunos64-sparcv9</module>
-        <module>leveldbjni-linux64-ppc64le</module>
+        <module>leveldbjni-linux64-ppc64le</module-->
         <module>leveldbjni-linux64-aarch64</module>
         <module>leveldbjni-all</module>
       </modules>
@@ -284,12 +296,12 @@
       </modules>
     </profile>
 
-    <profile>
+    <!--profile>
       <id>freebsd64</id>
       <modules>
         <module>leveldbjni-freebsd64</module>
       </modules>
-    </profile>
+    </profile-->
 
     <profile>
       <id>win32</id>
@@ -311,7 +323,7 @@
       </modules>
     </profile>
 
-    <profile>
+    <!--profile>
       <id>sunos64-amd64</id>
       <modules>
         <module>leveldbjni-sunos64-amd64</module>
@@ -330,7 +342,7 @@
       <modules>
         <module>leveldbjni-linux64-ppc64le</module>
       </modules>
-    </profile>
+    </profile-->
     <profile>
       <id>linux64-aarch64</id>
       <modules>


### PR DESCRIPTION
1.Update levedb.patch to support aarch64 platform
2.Update the groupid to org.openlabtesting.leveldbjni