### PR TITLE
Add s390x support

### DIFF
--- a/leveldbjni-all/pom.xml
+++ b/leveldbjni-all/pom.xml
@@ -110,6 +110,12 @@
     </dependency>
     <dependency>
       <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni-linux64-s390x</artifactId>
+      <version>99-master-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency> 
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-linux64-aarch64</artifactId>
       <version>99-master-SNAPSHOT</version>
       <scope>provided</scope>
@@ -155,6 +161,7 @@
 	      META-INF/native/sunos64/sparcv9/libleveldbjni.so;osname=SunOS;processor=sparcv9,
               META-INF/native/freebsd64/libleveldbjni.so;osname=FreeBSD;processor=x86-64,
               META-INF/native/linux64/ppc64le/libleveldbjni.so;osname=Linux;processor=ppc64le,
+              META-INF/native/linux64/s390x/libleveldbjni.so;osname=Linux;processor=s390x,
               META-INF/native/linux64/aarch64/libleveldbjni.so;osname=Linux;processor=aarch64
             </Bundle-NativeCode>
          </instructions>

--- a/leveldbjni-linux64-s390x/pom.xml
+++ b/leveldbjni-linux64-s390x/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright (C) 2011, FuseSource Corp.  All rights reserved.
+      http://fusesource.com
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of FuseSource Corp. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.fusesource.leveldbjni</groupId>
+    <artifactId>leveldbjni-project</artifactId>
+    <version>99-master-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.fusesource.leveldbjni</groupId>
+  <artifactId>leveldbjni-linux64-s390x</artifactId>
+  <version>99-master-SNAPSHOT</version>
+
+  <name>${project.artifactId}</name>
+  <description>The leveldbjni linux 64 native libraries on s390x machines</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.fusesource.leveldbjni</groupId>
+      <artifactId>leveldbjni</artifactId>
+      <version>99-master-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testSourceDirectory>${basedir}/../leveldbjni/src/test/java</testSourceDirectory>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <classesDirectory>${basedir}/target/generated-sources/hawtjni/lib</classesDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.fusesource.hawtjni</groupId>
+        <artifactId>maven-hawtjni-plugin</artifactId>
+        <version>${hawtjni-version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <platform>linux64/s390x</platform>
+          <name>leveldbjni</name>
+          <classified>false</classified>
+          <nativeSrcDependency>
+            <groupId>org.fusesource.leveldbjni</groupId>
+           <artifactId>leveldbjni</artifactId>
+            <version>${project.version}</version>
+            <classifier>native-src</classifier>
+            <type>zip</type>
+          </nativeSrcDependency>
+          <configureArgs>
+            <arg>--with-leveldb=${env.LEVELDB_HOME}</arg>
+            <arg>--with-snappy=${env.SNAPPY_HOME}</arg>
+            <arg>CFLAGS=-m64</arg>
+            <arg>CXXFLAGS=-m64</arg>
+          </configureArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.4.3</version>
+        <configuration>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <forkMode>once</forkMode>
+          <argLine>-d64 -ea</argLine>
+          <failIfNoTests>false</failIfNoTests>
+          <workingDirectory>${project.build.directory}</workingDirectory>
+          <includes>
+            <include>**/*Test.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
         <module>leveldbjni-sunos64-amd64</module>
         <module>leveldbjni-sunos64-sparcv9</module>
         <module>leveldbjni-linux64-ppc64le</module>
+        <module>leveldbjni-linux64-s390x</module>
         <module>leveldbjni-linux64-aarch64</module>
         <module>leveldbjni-all</module>
       </modules>
@@ -329,6 +330,12 @@
       <id>linux64-ppc64le</id>
       <modules>
         <module>leveldbjni-linux64-ppc64le</module>
+      </modules>
+    </profile>
+    <profile>
+     <id>linux64-s390x</id>
+     <modules>
+        <module>leveldbjni-linux64-s390x</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
To support leveldb-jni jar on s390x platform, some changes are made in pom.xml to add s390x as target platform. I have also added a target folder where the jni jar could be created.
To support build on s390x, I have also pushed a PR on leveldb [PR](https://github.com/chirino/leveldb/pull/5).
Please suggest if any other change is required.